### PR TITLE
Change LICENSE.TXT to MIT license

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,9 +1,7 @@
-Copyright 2020, ThinkNimble LLC
+Copyright 2022, ThinkNimble LLC
 
-ThinkNimble LLC does not grant its clients, agents, or third parties permission to
-use, remix, or distribute this software outside of the context of custom software
-built for the client by ThinkNimble.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-ThinkNimble grants its clients a perpetual and free license to use this software,
-so long as this software is included in the custom applications built for the
-client by ThinkNimble.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
We can change the license now, since this has been open-sourced like our other libraries.